### PR TITLE
Fix save output path

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -40,7 +40,7 @@ applied to the credentials being used! **
 
 		buildInstances := stx.GetBuildInstances(args, config.PackageName)
 
-		stx.Process(buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
+		stx.Process(config, buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
 
 			stacksIterator, stacksIteratorErr := stx.NewStacksIterator(cueInstance, flags, log)
 			if stacksIteratorErr != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -89,7 +89,7 @@ first.
 		workingGraph := graph.NewGraph()
 		buildInstances := stx.GetBuildInstances(args, config.PackageName)
 
-		stx.Process(buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
+		stx.Process(config, buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
 			stacksIterator, stacksIteratorErr := stx.NewStacksIterator(cueInstance, flags, log)
 			if stacksIteratorErr != nil {
 				log.Fatal(stacksIteratorErr)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -469,7 +469,7 @@ func deployStack(stack stx.Stack, buildInstance *build.Instance, stackValue cue.
 		log.Check()
 
 		if flags.DeploySave {
-			saveErr := saveStackOutputs(buildInstance, stack)
+			saveErr := saveStackOutputs(config, buildInstance, stack)
 			if saveErr != nil {
 				log.Fatal(saveErr)
 			}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -34,7 +34,7 @@ Diff is an implementation of https://github.com/homeport/dyff
 
 		buildInstances := stx.GetBuildInstances(args, config.PackageName)
 
-		stx.Process(buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
+		stx.Process(config, buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
 			stacksIterator, stacksIteratorErr := stx.NewStacksIterator(cueInstance, flags, log)
 			if stacksIteratorErr != nil {
 				log.Fatal(stacksIteratorErr)

--- a/cmd/events.go
+++ b/cmd/events.go
@@ -27,7 +27,7 @@ For each stack, events will query CloudFormation and return a list of events.`,
 
 		buildInstances := stx.GetBuildInstances(args, config.PackageName)
 
-		stx.Process(buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
+		stx.Process(config, buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
 			stacksIterator, stacksIteratorErr := stx.NewStacksIterator(cueInstance, flags, log)
 			if stacksIteratorErr != nil {
 				log.Fatal(stacksIteratorErr)

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -40,7 +40,7 @@ infrastructure/
 
 		buildInstances := stx.GetBuildInstances(args, config.PackageName)
 
-		stx.Process(buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
+		stx.Process(config, buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
 			stacksIterator, stacksIteratorErr := stx.NewStacksIterator(cueInstance, flags, log)
 			if stacksIteratorErr != nil {
 				log.Fatal(stacksIteratorErr)

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -32,7 +32,7 @@ Each stack will be converted to YAML then printed to stdout.`,
 		log.Debug("Getting build instances...")
 		buildInstances := stx.GetBuildInstances(args, config.PackageName)
 		log.Debug("Processing build instances...")
-		stx.Process(buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
+		stx.Process(config, buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
 
 			stacksIterator, stacksIteratorErr := stx.NewStacksIterator(cueInstance, flags, log)
 			if stacksIteratorErr != nil {

--- a/cmd/resources.go
+++ b/cmd/resources.go
@@ -34,7 +34,7 @@ resources currently managed in the stack.
 
 		buildInstances := stx.GetBuildInstances(args, config.PackageName)
 
-		stx.Process(buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
+		stx.Process(config, buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
 			stacksIterator, stacksIteratorErr := stx.NewStacksIterator(cueInstance, flags, log)
 			if stacksIteratorErr != nil {
 				log.Fatal(stacksIteratorErr)

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -22,22 +22,28 @@ var saveCmd = &cobra.Command{
 	
 For each stack that has Outputs defined, save will query CloudFormation
 and write the Outputs as cue-formatted key:value pairs. Each stack will be
-saved as its own file with a .out.cue extension. 
+saved as its own file with a .out.cue extension.
 
-By default the files will be stored in the same directory as the stack was defined,
-but this can be overridden in config.stx.cue with:
+The outputs do not themselves need to be defined in Cue. For example if you have
+stacks that were deployed with some other tool, all you need is the stack name,
+profile, and region to be defined in Cue. From there stx will pull outputs from
+the CloudFormation API.
+
+By default the output files will be stored in the same directory as the stack was
+defined, but this can be overridden in config.stx.cue via:
 
 Cmd: Save: OutFilePrefix: ""
 
-For example if you want all your file viewer to group output files together you could
-set the prefix to "z-" to get them grouped at the bottom. To get them grouped together
-at the top, set the prefix to something like "0-" or "0ut-".
+This string is completely arbitrary, and it supports directories if ending with a "/".
 
-This string is completely arbitrary and up to you, and it supports directories if ending
-with a "/".
+For example if you want your file viewer to group output files together, you could
+set the prefix to "z-" to get them grouped at the bottom. To get them grouped together
+at the top, set the prefix to something like "0-" or "0ut-" as examples. To put them
+in a subfolder set the prefix to something like "outputs/"
 
 NOTE: Cue will not load files that begin with underscore, so avoid setting prefix to "_"
 or any string that begins with "_".
+
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 
@@ -46,7 +52,7 @@ or any string that begins with "_".
 
 		buildInstances := stx.GetBuildInstances(args, config.PackageName)
 
-		stx.Process(buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
+		stx.Process(config, buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
 			stacksIterator, stacksIteratorErr := stx.NewStacksIterator(cueInstance, flags, log)
 			if stacksIteratorErr != nil {
 				log.Fatal(stacksIteratorErr)

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/build"
@@ -94,35 +92,12 @@ func saveStackOutputs(buildInstance *build.Instance, stack stx.Stack) error {
 		return nil
 	}
 
-	// cfn.out files are store under cue.mod/usr/cfn.out with the same relative path as the stacks cue instance
-	// for example a stack with a template declared in cue/engineering/eks/cluster
-	// with a concrete leaf in cue/engineering/eks/cluster/dev-usw2
-	// would store outputs in cue.mod/usr/cfn.out/cue/engineering/eks/cluster
-	instancePath := buildInstance.Dir
-	// in case no template.cfn.cue file is found, use the instance (relative) path
-	cueOutPath := strings.Replace(instancePath, buildInstance.Root, "", 1)
-
-	// look for the template.cfn.cue file for the current build instance
-	dirs := strings.Split(instancePath, config.OsSeparator)
-	path := ""
-	// traverse the directory tree starting from leaf going up to successive parents
-	for i := len(dirs); i > 0; i-- {
-		path = strings.Join(dirs[:i], config.OsSeparator)
-		// look for the template file
-		if _, err := os.Stat(path + config.OsSeparator + "template.cfn.cue"); !os.IsNotExist(err) {
-			break // found it!
-		}
-	}
-	if path != "" {
-		cueOutPath = strings.Replace(path, buildInstance.Root, "", 1)
-	}
-	cueOutPath = strings.Replace(buildInstance.Root+"/cue.mod/usr/cfn.out"+cueOutPath, "-", "", -1)
-	fileName := cueOutPath + "/" + stack.Name + ".out.cue"
+	cueOutPath := buildInstance.Dir + "/cfnout/"
+	fileName := cueOutPath + stack.Name + ".out.cue"
 	log.Infof("%s %s %s %s\n", au.White("Saving"), au.Magenta(stack.Name), au.White("⤏"), fileName)
 
 	// create the .out.cue file
-	cuePackage := filepath.Base(cueOutPath)
-	result := "package " + cuePackage + "\n\n\"" + stack.Name + "\": {\n"
+	result := "package cfnout" + "\n\n\"" + stack.Name + "\": {\n"
 	// convert cloudformation outputs into simple key:value pairs
 	for _, output := range describeStacksOutput.Stacks[0].Outputs {
 		result += fmt.Sprintf("\"%s\":\"%s\"\n", aws.StringValue(output.OutputKey), aws.StringValue(output.OutputValue))
@@ -138,7 +113,7 @@ func saveStackOutputs(buildInstance *build.Instance, stack stx.Stack) error {
 
 	// save it!
 	os.MkdirAll(cueOutPath, 0766)
-	writeErr := ioutil.WriteFile(fileName, cueOutput, 0644)
+	writeErr := ioutil.WriteFile(fileName, []byte(cueOutput), 0644)
 	if writeErr != nil {
 		return writeErr
 	}

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -24,10 +24,10 @@ For each stack that has Outputs defined, save will query CloudFormation
 and write the Outputs as cue-formatted key:value pairs. Each stack will be
 saved as its own file with a .out.cue extension.
 
-The outputs do not themselves need to be defined in Cue. For example if you have
-stacks that were deployed with some other tool, all you need is the stack name,
-profile, and region to be defined in Cue. From there stx will pull outputs from
-the CloudFormation API.
+The outputs themselves do not need to be defined in Cue. For example if you
+want to reference outputs in stacks that were deployed with some other tool,
+all you need is the stack name, profile, and region to be defined in Cue.
+From there stx will pull outputs from the CloudFormation API.
 
 By default the output files will be stored in the same directory as the stack was
 defined, but this can be overridden in config.stx.cue via:

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -24,26 +24,20 @@ For each stack that has Outputs defined, save will query CloudFormation
 and write the Outputs as cue-formatted key:value pairs. Each stack will be
 saved as its own file with a .out.cue extension. 
 
-To determine where these .out.cue files are saved, stx uses the path of the
-stack's template.cfn.cue file relative to the cue root. If no template.cfn.cue
-file is found, stx will use the path of the concrete leaf, relative to cue root.
+By default the files will be stored in the same directory as the stack was defined,
+but this can be overridden in config.stx.cue with:
 
-As an example, consider the following tree:
+Cmd: Save: OutFilePrefix: ""
 
-infrastructure/
-|-cue/                                      ("cue root")
-| |-cue.mod/
-| | |-usr/cfn.out/vpc/dev-vpc-usw2.out.cue  (outputs file)
-| |-vpc/
-| | |-template.cfn.cue                      (template)
+For example if you want all your file viewer to group output files together you could
+set the prefix to "z-" to get them grouped at the bottom. To get them grouped together
+at the top, set the prefix to something like "0-" or "0ut-".
 
-Running stx save from infrastructure/cue/vpc/ will find the stack "dev-vpc-usw2"
-defined in the template.cfn.cue file. stx will use vpc/ as the path relative to
-cue root to create vpc/ as the path relative to cfn.out.
+This string is completely arbitrary and up to you, and it supports directories if ending
+with a "/".
 
-The outputs file in this example will declare its cue package as "vpc" since
-that is the folder in which it is contained. Note that special characters such
-as spaces or hyphens will be removed from folder and package names.
+NOTE: Cue will not load files that begin with underscore, so avoid setting prefix to "_"
+or any string that begins with "_".
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -29,7 +29,7 @@ If the stack does not exist status will return an error.
 
 		buildInstances := stx.GetBuildInstances(args, config.PackageName)
 
-		stx.Process(buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
+		stx.Process(config, buildInstances, flags, log, func(buildInstance *build.Instance, cueInstance *cue.Instance) {
 			log.Debug("status command processing...")
 			stacksIterator, stacksIteratorErr := stx.NewStacksIterator(cueInstance, flags, log)
 			if stacksIteratorErr != nil {

--- a/stx/config.go
+++ b/stx/config.go
@@ -33,6 +33,9 @@ Cmd: {
 			TopicArn: string | *""
 		}
 	}
+	Save: {
+		OutFilePrefix: string | *""
+	}
 }
 PackageName: string | *"cfn"
 `
@@ -58,6 +61,9 @@ type Config struct {
 			Notify struct {
 				Endpoint, TopicArn string
 			}
+		}
+		Save struct {
+			OutFilePrefix string
 		}
 	}
 }

--- a/stx/instances.go
+++ b/stx/instances.go
@@ -1,7 +1,6 @@
 package stx
 
 import (
-	"path/filepath"
 	"regexp"
 
 	"cuelang.org/go/cue"
@@ -62,11 +61,6 @@ func Process(buildInstances []*build.Instance, flags Flags, log *logger.Logger, 
 
 	log.Debug("Iterating", len(buildInstances), "build instances...")
 	for _, buildInstance := range buildInstances {
-		if filepath.Base(buildInstance.Dir) == "cfnout" {
-			// don't process output folders as build instances
-			continue
-		}
-
 		if excludeRegexp != nil && excludeRegexp.MatchString(buildInstance.DisplayPath) {
 			log.Debug("Excluded via --exlude: ", buildInstance.DisplayPath)
 			continue

--- a/stx/instances.go
+++ b/stx/instances.go
@@ -1,6 +1,7 @@
 package stx
 
 import (
+	"path/filepath"
 	"regexp"
 
 	"cuelang.org/go/cue"
@@ -61,6 +62,11 @@ func Process(buildInstances []*build.Instance, flags Flags, log *logger.Logger, 
 
 	log.Debug("Iterating", len(buildInstances), "build instances...")
 	for _, buildInstance := range buildInstances {
+		if filepath.Base(buildInstance.Dir) == "cfnout" {
+			// don't process output folders as build instances
+			continue
+		}
+
 		if excludeRegexp != nil && excludeRegexp.MatchString(buildInstance.DisplayPath) {
 			log.Debug("Excluded via --exlude: ", buildInstance.DisplayPath)
 			continue


### PR DESCRIPTION
Previously `save` would write `cfn.out` files to `cue.mod/usr/cfn.out` but this caused several issues:

- finding the outputs in a different part of the file tree was inconvenient
- having a nearly indentical file tree with nearly identical file names under cue.mod made it all to easy to go looking for stacks under cue.mod only to find outputs instead.

By colocating the outputs with the stack it eases the developer experience